### PR TITLE
fix: Remove `sudo` from the commands in the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ upgrade:
 	@echo "Upgrading dependencies..."
 	go get -u
 
-build_up: 
+build_up:
 	@echo "Building pano-api..."
-	sudo docker compose up --build --remove-orphans
+	docker compose up --build --remove-orphans
 
 up:
 	@echo "Starting docker-compose..."
-	sudo docker compose up 
+	docker compose up
 
 down:
 	@echo "Stopping docker-compose..."
-	sudo docker compose down --remove-orphans
+	docker compose down --remove-orphans


### PR DESCRIPTION
We don't need `sudo` permissions to run an application with `docker compose`. 